### PR TITLE
Make GXSerial consistent with other IGXMedia(s)

### DIFF
--- a/development/src/main/java/gurux/serial/GXSerial.java
+++ b/development/src/main/java/gurux/serial/GXSerial.java
@@ -943,6 +943,10 @@ public class GXSerial implements IGXMedia, IGXMedia2, AutoCloseable {
 
     @Override
     public final long getBytesReceived() {
+        if(this.receiver == null)
+        {
+            return 0;
+        }
         return receiver.getBytesReceived();
     }
 


### PR DESCRIPTION
This is done in `GXNet` but not in `GXSerial` and I am running into this when I have a failed `open()` but have statistics collecting code run at the end.